### PR TITLE
Adds getMetric route handler as well as the body-parser npm package.

### DIFF
--- a/Controllers/AppController.js
+++ b/Controllers/AppController.js
@@ -38,7 +38,7 @@ exports.updateCPUUtil = () => {
   request(
     {
       url:
-        "http://localhost:8001/redfish/v1/TelemetryService/MetricReports/CPUMetrics",
+        "http://localhost:8000/redfish/v1/TelemetryService/MetricReports/CPUMetrics",
       json: true
     },
     (error, response, body) => {
@@ -145,6 +145,23 @@ exports.getPanels = function(req, res) {
     pageTitle: "Redfish Telemetry Client",
     currentYear: new Date().getFullYear()
   });
+};
+
+// Route handler for /metrics
+exports.getAvailableMetrics = function(req, res) {
+  request(
+    {
+      url: "http://localhost:8000/redfish/v1/TelemetryService/MetricReports",
+      json: true
+    },
+    (error, response, body) => {
+      if (error) {
+        console.log(error);
+      } else {
+        res.json(body.Members);
+      }
+    }
+  );
 };
 
 // Grab Influx Data. Can we do this without nesting?

--- a/routes/baseRoutes.js
+++ b/routes/baseRoutes.js
@@ -3,6 +3,7 @@ const path = require("path");
 const app_controller = require("../Controllers/AppController");
 
 module.exports = app => {
-   app.use(express.static("./Resources"));
-   app.get("/", app_controller.getPanels);
+  app.use(express.static("./Resources"));
+  app.get("/", app_controller.getPanels);
+  app.get("/metrics", app_controller.getAvailableMetrics);
 };


### PR DESCRIPTION
This route is /metrics/:metric where :metric is the selected metric from the list returned by getAvailableMetrics. The return from getAvailableMetrics needs to be improved to return an array of metrics that are cut from the current return value, which is an array of URLs straight from the JSON. I will create a new task for this.